### PR TITLE
fix(sats-wagmi): handle account change

### DIFF
--- a/apps/evm/src/pages/Bridge/components/BridgeForm/BtcBridgeForm.tsx
+++ b/apps/evm/src/pages/Bridge/components/BridgeForm/BtcBridgeForm.tsx
@@ -8,7 +8,7 @@ import {
   useFeeEstimate as useSatsFeeEstimate
 } from '@gobob/sats-wagmi';
 import { BITCOIN } from '@gobob/tokens';
-import { Alert, Avatar, Flex, Input, Item, P, Select, TokenInput, toast, useForm } from '@gobob/ui';
+import { Alert, Avatar, Flex, Input, Item, P, Select, TokenInput, Tooltip, toast, useForm } from '@gobob/ui';
 import { useAccount, useIsContract } from '@gobob/wagmi';
 import { mergeProps } from '@react-aria/utils';
 import { useDebounce } from '@uidotdev/usehooks';
@@ -310,7 +310,11 @@ const BtcBridgeForm = ({
     <Flex direction='column' elementType='form' gap='xl' marginTop='md' onSubmit={form.handleSubmit as any}>
       <TokenInput
         balance={balanceAmount.toExact()}
-        balanceLabel='Available'
+        balanceLabel={
+          <Tooltip label='Your available balance may differ from your wallet balance due to network fees and available liquidity'>
+            Available
+          </Tooltip>
+        }
         currency={BITCOIN}
         humanBalance={humanBalanceAmount?.toExact()}
         label='Amount'

--- a/packages/sats-wagmi/src/connectors/base.ts
+++ b/packages/sats-wagmi/src/connectors/base.ts
@@ -113,6 +113,10 @@ abstract class SatsConnector {
     return this.publicKey;
   }
 
+  abstract on(callback: (account: string) => void): void;
+
+  abstract removeListener(callback: (account: string) => void): void;
+
   // TODO: verify if this works on mainnet
   async sendInscription(): Promise<string> {
     throw new Error('Not implemented');

--- a/packages/sats-wagmi/src/connectors/leather.ts
+++ b/packages/sats-wagmi/src/connectors/leather.ts
@@ -105,6 +105,10 @@ class LeatherConnector extends SatsConnector {
     this.derivationPath = paymentAccount.derivationPath;
   }
 
+  on(): void {}
+
+  removeListener(): void {}
+
   async isReady() {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     this.ready = !!(window as any).LeatherProvider;

--- a/packages/sats-wagmi/src/connectors/mm-snap.ts
+++ b/packages/sats-wagmi/src/connectors/mm-snap.ts
@@ -113,6 +113,10 @@ class MMSnapConnector extends SatsConnector {
     return Object.keys(snaps || {}).includes(snapId);
   }
 
+  on(): void {}
+
+  removeListener(): void {}
+
   async getExtendedPublicKey() {
     if (this.extendedPublicKey) {
       return this.extendedPublicKey;

--- a/packages/sats-wagmi/src/connectors/okx.ts
+++ b/packages/sats-wagmi/src/connectors/okx.ts
@@ -111,6 +111,16 @@ class OKXConnector extends SatsConnector {
     return window.okxwallet.bitcoin.signMessage(message);
   }
 
+  on(callback: (account: string) => void): void {
+    window.okxwallet.bitcoin.on('accountChanged', ({ address, publicKey, compressedPublicKey }) => {
+      callback(address);
+
+      this.changeAccount({ address, publicKey, compressedPublicKey });
+    });
+  }
+
+  removeListener(): void {}
+
   async changeAccount({ address, publicKey }: AccountChangeEventParams) {
     this.address = address;
     this.publicKey = publicKey;

--- a/packages/sats-wagmi/src/connectors/unisat.ts
+++ b/packages/sats-wagmi/src/connectors/unisat.ts
@@ -137,22 +137,34 @@ class UnisatConnector extends SatsConnector {
     this.paymentAddress = accounts[0];
     this.ordinalsAddress = accounts[0];
     this.publicKey = publickKey;
-
-    walletSource.on('accountsChanged', this.changeAccount);
   }
 
   disconnect() {
     this.address = undefined;
     this.publicKey = undefined;
-
-    this.getSource().removeListener('accountsChanged', this.changeAccount);
   }
 
   signMessage(message: string) {
     return this.getSource().signMessage(message);
   }
 
-  async changeAccount([account]: string[]) {
+  on(callback: (account: string) => void): void {
+    this.getSource().on('accountsChanged', ([account]) => {
+      callback(account);
+
+      this.changeAccount(account);
+    });
+  }
+
+  removeListener(callback: (account: string) => void): void {
+    this.getSource().removeListener('accountsChanged', ([account]) => {
+      callback(account);
+
+      this.changeAccount(account);
+    });
+  }
+
+  async changeAccount(account: string) {
     this.address = account;
     this.publicKey = await this.getSource().getPublicKey();
   }

--- a/packages/sats-wagmi/src/connectors/xverse.ts
+++ b/packages/sats-wagmi/src/connectors/xverse.ts
@@ -74,6 +74,10 @@ class XverseConnector extends SatsConnector {
     });
   }
 
+  on(): void {}
+
+  removeListener(): void {}
+
   async isReady() {
     this.ready = !!window.XverseProviders;
 

--- a/packages/sats-wagmi/src/hooks/useAccount.tsx
+++ b/packages/sats-wagmi/src/hooks/useAccount.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from '@gobob/react-query';
 import { getAddressInfo } from 'bitcoin-address-validation';
+import { useEffect } from 'react';
 
 import { useSatsWagmi } from '../provider';
 import { SatsConnector } from '../connectors';
@@ -12,7 +13,7 @@ const useAccount = ({ onConnect }: UseAccountProps = {}) => {
   const { connector } = useSatsWagmi();
 
   const { data, error, isError, isLoading, isSuccess, refetch } = useQuery({
-    queryKey: ['account', connector],
+    queryKey: ['sats-account', connector],
     queryFn: () => {
       if (!connector) return undefined;
 
@@ -26,6 +27,16 @@ const useAccount = ({ onConnect }: UseAccountProps = {}) => {
     },
     enabled: !!connector
   });
+
+  useEffect(() => {
+    if (!connector) return;
+
+    connector.on(() => refetch());
+
+    return () => {
+      connector.removeListener(() => refetch());
+    };
+  }, [connector, refetch]);
 
   return {
     connector,

--- a/packages/sats-wagmi/src/hooks/useDisconnect.tsx
+++ b/packages/sats-wagmi/src/hooks/useDisconnect.tsx
@@ -6,7 +6,7 @@ const useDisconnect = () => {
   const { setConnector } = useSatsWagmi();
 
   const { mutate, mutateAsync, ...mutation } = useMutation({
-    mutationKey: ['disconnect'],
+    mutationKey: ['sats-disconnect'],
     mutationFn: async () => {
       setConnector(undefined);
     }

--- a/packages/sats-wagmi/src/provider.tsx
+++ b/packages/sats-wagmi/src/provider.tsx
@@ -36,7 +36,6 @@ type SatsWagmiConfigProps = {
   network?: BitcoinNetwork;
 };
 
-// TODO: implement auto-connect
 const SatsWagmiConfig: FC<SatsWagmiConfigProps> = ({ children, network = 'mainnet' }) => {
   const [connectors, setConnectors] = useState<SatsConnector[]>([]);
   const [connector, setCurrentConnector] = useState<SatsConnector>();

--- a/packages/ui/src/components/Tooltip/Tooltip.tsx
+++ b/packages/ui/src/components/Tooltip/Tooltip.tsx
@@ -81,7 +81,7 @@ const Tooltip = forwardRef<HTMLDivElement, TooltipProps>((props, ref): JSX.Eleme
 
   if (shouldWrap) {
     trigger = (
-      <Span ref={tooltipTriggerRef} tabIndex={0} {...triggerProps}>
+      <Span ref={tooltipTriggerRef} size='inherit' tabIndex={0} {...triggerProps}>
         {children}
       </Span>
     );


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!
-->

## 📝 Description

Some wallets provide an api for account change within the wallet, such as for unisat and OKX. This is important so that our app reflects the changes within the wallet.

## ⛳️ Current behavior (updates)

Address could sometimes not match wallet

## 🚀 New behavior

Address walways matcges wallet

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information