### PR TITLE
chore: stop indexing custom wseth bridge

### DIFF
--- a/apps/evm/src/indexer/bridge/new_testnet_bridge_deposits.json
+++ b/apps/evm/src/indexer/bridge/new_testnet_bridge_deposits.json
@@ -19,12 +19,6 @@
       "address": "0xA932eD4b73972c37DC4a691E8eC6f2C8a13951BE",
       "startBlock": 6441278,
       "chain": "sepolia"
-    },
-    {
-      "abi": "bridge",
-      "address": "0x6fD5030EBa8399E791492721b20932A60875E32D",
-      "startBlock": 6442089,
-      "chain": "sepolia"
     }
   ]
 }

--- a/apps/evm/src/indexer/bridge/new_testnet_bridge_withdraws.json
+++ b/apps/evm/src/indexer/bridge/new_testnet_bridge_withdraws.json
@@ -19,12 +19,6 @@
       "address": "0x5C2A45A35ba99d8Ee58c4bB96e2Ce30dA86C530b",
       "startBlock": 253101,
       "chain": "bob-sepolia"
-    },
-    {
-      "abi": "bridge",
-      "address": "0x087EB402f82b23b368f6a7d1ed606E8371c79CBE",
-      "startBlock": 257214,
-      "chain": "bob-sepolia"
     }
   ]
 }


### PR DESCRIPTION
The PR does
- stop indexing the custom `wstETH`custom bridge as we are using default standard bridge instead

`Note`: The GQL endpoints won't change