### PR TITLE
feat(indexer): index optimism portal contract in the subgraph

### DIFF
--- a/apps/evm/src/app/[lang]/(bridge)/hooks/useGetBridgeTransactions.ts
+++ b/apps/evm/src/app/[lang]/(bridge)/hooks/useGetBridgeTransactions.ts
@@ -5,7 +5,7 @@ import { INTERVAL, useQueries, useQuery } from '@gobob/react-query';
 import { Address, useAccount } from '@gobob/wagmi';
 import request, { gql } from 'graphql-request';
 import { useCallback } from 'react';
-import { TransactionReceipt, isAddressEqual } from 'viem';
+import { TransactionReceipt, decodeAbiParameters, isAddressEqual, parseAbiParameters } from 'viem';
 import { GetWithdrawalStatusReturnType, getL2TransactionHashes, getWithdrawals } from 'viem/op-stack';
 import { useStore } from '@tanstack/react-store';
 
@@ -15,47 +15,62 @@ import { useBridgeTokens, usePublicClientL1, usePublicClientL2 } from '@/hooks';
 import { ETH, L1_CHAIN, L2_CHAIN, wstETH } from '@/constants';
 import { bridgeKeys, queryClient } from '@/lib/react-query';
 
-type Erc20TransactionResponse = {
-  remoteToken: Address;
-  localToken: Address;
-} & EthTransactionResponse;
-
-type EthTransactionResponse = {
+type BaseTransactionResponse = {
   from: Address;
   to: Address;
   blockNumber: number;
   transactionHash: Address;
   timestamp: number;
-  amount: bigint;
-  data: string;
 };
 
-type BridgeTransactionResponse = {
-  eth: EthTransactionResponse[];
+type Erc20TransactionResponse = BaseTransactionResponse & {
+  remoteToken: Address;
+  localToken: Address;
+  amount: bigint;
+};
+
+type EthTransactionResponse = BaseTransactionResponse & {
+  amount: bigint;
+};
+
+type EthRawTransactionResponse = BaseTransactionResponse & {
+  opaqueData: Address;
+};
+
+type BridgeDepositTransactionResponse = {
+  l1StandardBridgeEth: EthTransactionResponse[];
+  optimismPortalEth: EthRawTransactionResponse[];
   erc20: Erc20TransactionResponse[];
 };
 
-type WithdrawBridgeTransactionResponse = BridgeTransactionResponse & {
-  westEth: Erc20TransactionResponse[];
+type BridgeWithdrawTransactionResponse = {
+  l1StandardBridgeEth: EthTransactionResponse[];
+  l2MessagePasserEth: EthTransactionResponse[];
+  erc20: Erc20TransactionResponse[];
+  westEth?: Erc20TransactionResponse[];
 };
 
 type RawTransactionsData = {
-  deposits: BridgeTransactionResponse;
-  withdraws: BridgeTransactionResponse & {
-    westEth?: Erc20TransactionResponse[];
-  };
+  deposits: BridgeDepositTransactionResponse;
+  withdraws: BridgeWithdrawTransactionResponse;
 };
-
 const getDepositBridgeTransactions = gql`
   query getBridgeDeposits($address: String!) {
-    eth: ethbridgeInitiateds(where: { from_starts_with_nocase: $address }) {
+    l1StandardBridgeEth: ethbridgeInitiateds(where: { from_starts_with_nocase: $address }) {
       from
       to
       blockNumber: block_number
       transactionHash: transactionHash_
       timestamp: timestamp_
       amount
-      data: extraData
+    }
+    optimismPortalEth: transactionDepositeds(where: { from_starts_with_nocase: $address }) {
+      from
+      to
+      blockNumber: block_number
+      transactionHash: transactionHash_
+      timestamp: timestamp_
+      opaqueData
     }
     erc20: erc20BridgeInitiateds(where: { from_starts_with_nocase: $address }) {
       from
@@ -66,21 +81,27 @@ const getDepositBridgeTransactions = gql`
       transactionHash: transactionHash_
       timestamp: timestamp_
       amount
-      data: extraData
     }
   }
 `;
 
 const getWithdrawBridgeTransactions = (enableWestEth: boolean) => gql`
   query getBridgeDeposits($address: String!, $westEthAddress: String) {
-    eth: ethbridgeInitiateds(where: { from_starts_with_nocase: $address }) {
+    l1StandardBridgeEth: ethbridgeInitiateds(where: { from_starts_with_nocase: $address }) {
       from
       to
       blockNumber: block_number
       transactionHash: transactionHash_
       timestamp: timestamp_
       amount
-      data: extraData
+    }
+    l2MessagePasserEth: messagePasseds(where: { sender_starts_with_nocase: "0x97632B3760460A623E068CC70aBF11D5fA99Be5f" }) {
+      from: sender
+      to: target
+      blockNumber: block_number
+      transactionHash: transactionHash_
+      timestamp: timestamp_
+      amount: value
     }
     erc20: erc20BridgeInitiateds(where: { from_starts_with_nocase: $address }) {
       from
@@ -91,7 +112,6 @@ const getWithdrawBridgeTransactions = (enableWestEth: boolean) => gql`
       transactionHash: transactionHash_
       timestamp: timestamp_
       amount
-      data: extraData
     }
    ${
      enableWestEth
@@ -104,7 +124,6 @@ const getWithdrawBridgeTransactions = (enableWestEth: boolean) => gql`
       transactionHash: transactionHash_
       timestamp: timestamp_
       amount
-      data: extraData
     }`
        : ''
    }
@@ -112,7 +131,7 @@ const getWithdrawBridgeTransactions = (enableWestEth: boolean) => gql`
 `;
 
 const { deposit: depositUrlPath, withdraw: withdrawUrlPath } = {
-  [ChainId.BOB]: { deposit: 'bridge-deposits-mainnet/1.0/gn', withdraw: 'bridge-withdraws-bob/1.0/gn' },
+  [ChainId.BOB]: { deposit: 'bridge-deposits-mainnet/prod/gn', withdraw: 'bridge-withdraws-bob/prod/gn' },
   [ChainId.BOB_SEPOLIA]: {
     deposit: 'testnet-bridge-deposits-sepolia/test/gn',
     withdraw: 'testnet-bridge-withdraws-bob-sepolia/test/gn'
@@ -432,8 +451,8 @@ const useGetBridgeTransactions = () => {
     const westEthAddress = L2_CHAIN === ChainId.BOB_SEPOLIA ? undefined : wstETH[L2_CHAIN].address.toLowerCase();
 
     const [deposits, withdraws] = await Promise.all([
-      request<BridgeTransactionResponse>(depositsUrl, getDepositBridgeTransactions, { address }),
-      request<WithdrawBridgeTransactionResponse>(withdrawUrl, getWithdrawBridgeTransactions(!!westEthAddress), {
+      request<BridgeDepositTransactionResponse>(depositsUrl, getDepositBridgeTransactions, { address }),
+      request<BridgeWithdrawTransactionResponse>(withdrawUrl, getWithdrawBridgeTransactions(!!westEthAddress), {
         address,
         westEthAddress
       })
@@ -457,7 +476,19 @@ const useGetBridgeTransactions = () => {
 
     const enabled = !!transactions.data;
 
-    const depositsEth = transactions.data.deposits.eth.map((tx) => ({
+    const transformedDepositData = transactions.data.deposits.optimismPortalEth.map(
+      ({ opaqueData, ...tx }): EthTransactionResponse => ({
+        ...tx,
+        amount: decodeAbiParameters(parseAbiParameters('uint256 mint, uint256 value'), opaqueData)[1]
+      })
+    );
+
+    const ethDeposits: EthTransactionResponse[] = [
+      ...transactions.data.deposits.l1StandardBridgeEth,
+      ...transformedDepositData
+    ];
+
+    const depositsEth = ethDeposits.map((tx) => ({
       queryKey: bridgeKeys.depositEthTransaction(address, tx.transactionHash),
       queryFn: () => getEthDeposit(tx),
       refetchInterval: getDepositRefetchInterval,
@@ -466,7 +497,12 @@ const useGetBridgeTransactions = () => {
       enabled
     }));
 
-    const withdrawsEth = transactions.data.withdraws.eth.map((tx) => ({
+    const ethWithdraw = [
+      ...transactions.data.withdraws.l1StandardBridgeEth,
+      ...transactions.data.withdraws.l2MessagePasserEth
+    ];
+
+    const withdrawsEth = ethWithdraw.map((tx) => ({
       queryKey: bridgeKeys.withdrawEthTransaction(address, tx.transactionHash),
       queryFn: () => getEthWithdraw(tx),
       refetchInterval: getWithdrawRefetchInterval,

--- a/apps/evm/src/indexer/bridge/L2ToL1MessagePasserABI.json
+++ b/apps/evm/src/indexer/bridge/L2ToL1MessagePasserABI.json
@@ -1,0 +1,156 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "nonce",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "target",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "gasLimit",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "withdrawalHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "MessagePassed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "WithdrawerBalanceBurnt",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "MESSAGE_VERSION",
+    "outputs": [
+      {
+        "internalType": "uint16",
+        "name": "",
+        "type": "uint16"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "burn",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_target",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_gasLimit",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_data",
+        "type": "bytes"
+      }
+    ],
+    "name": "initiateWithdrawal",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "messageNonce",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "sentMessages",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "version",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "stateMutability": "payable",
+    "type": "receive"
+  }
+]

--- a/apps/evm/src/indexer/bridge/OptimismPortal.json
+++ b/apps/evm/src/indexer/bridge/OptimismPortal.json
@@ -1,0 +1,527 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "contract L2OutputOracle",
+        "name": "_l2Oracle",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_guardian",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "_paused",
+        "type": "bool"
+      },
+      {
+        "internalType": "contract SystemConfig",
+        "name": "_config",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint8",
+        "name": "version",
+        "type": "uint8"
+      }
+    ],
+    "name": "Initialized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "Paused",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "version",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "opaqueData",
+        "type": "bytes"
+      }
+    ],
+    "name": "TransactionDeposited",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "Unpaused",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "withdrawalHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "success",
+        "type": "bool"
+      }
+    ],
+    "name": "WithdrawalFinalized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "withdrawalHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      }
+    ],
+    "name": "WithdrawalProven",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "GUARDIAN",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "L2_ORACLE",
+    "outputs": [
+      {
+        "internalType": "contract L2OutputOracle",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "SYSTEM_CONFIG",
+    "outputs": [
+      {
+        "internalType": "contract SystemConfig",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_value",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint64",
+        "name": "_gasLimit",
+        "type": "uint64"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isCreation",
+        "type": "bool"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_data",
+        "type": "bytes"
+      }
+    ],
+    "name": "depositTransaction",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "donateETH",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "nonce",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "sender",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "target",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "value",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "gasLimit",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes",
+            "name": "data",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct Types.WithdrawalTransaction",
+        "name": "_tx",
+        "type": "tuple"
+      }
+    ],
+    "name": "finalizeWithdrawalTransaction",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "finalizedWithdrawals",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bool",
+        "name": "_paused",
+        "type": "bool"
+      }
+    ],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_l2OutputIndex",
+        "type": "uint256"
+      }
+    ],
+    "name": "isOutputFinalized",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "l2Sender",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "_byteCount",
+        "type": "uint64"
+      }
+    ],
+    "name": "minimumGasLimit",
+    "outputs": [
+      {
+        "internalType": "uint64",
+        "name": "",
+        "type": "uint64"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "params",
+    "outputs": [
+      {
+        "internalType": "uint128",
+        "name": "prevBaseFee",
+        "type": "uint128"
+      },
+      {
+        "internalType": "uint64",
+        "name": "prevBoughtGas",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint64",
+        "name": "prevBlockNum",
+        "type": "uint64"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pause",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "paused",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "nonce",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "sender",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "target",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "value",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "gasLimit",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes",
+            "name": "data",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct Types.WithdrawalTransaction",
+        "name": "_tx",
+        "type": "tuple"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_l2OutputIndex",
+        "type": "uint256"
+      },
+      {
+        "components": [
+          {
+            "internalType": "bytes32",
+            "name": "version",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "stateRoot",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "messagePasserStorageRoot",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "latestBlockhash",
+            "type": "bytes32"
+          }
+        ],
+        "internalType": "struct Types.OutputRootProof",
+        "name": "_outputRootProof",
+        "type": "tuple"
+      },
+      {
+        "internalType": "bytes[]",
+        "name": "_withdrawalProof",
+        "type": "bytes[]"
+      }
+    ],
+    "name": "proveWithdrawalTransaction",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "provenWithdrawals",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "outputRoot",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint128",
+        "name": "timestamp",
+        "type": "uint128"
+      },
+      {
+        "internalType": "uint128",
+        "name": "l2OutputIndex",
+        "type": "uint128"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "unpause",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "version",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "stateMutability": "payable",
+    "type": "receive"
+  }
+]

--- a/apps/evm/src/indexer/bridge/README.md
+++ b/apps/evm/src/indexer/bridge/README.md
@@ -8,7 +8,7 @@ To access user deposit transactions from Layer 1 (L1) to Layer 2 (L2), utilize t
 
 - **Old Testnet:** `https://api.goldsky.com/api/public/project_clto8zgmd1jbw01xig1ge1u0h/subgraphs/bridge-deposits-sepolia/1.0/gn`
 - **New Testnet:** `https://api.goldsky.com/api/public/project_clto8zgmd1jbw01xig1ge1u0h/subgraphs/testnet-bridge-deposits-sepolia/test/gn`
-- **Mainnet:** `https://api.goldsky.com/api/public/project_clto8zgmd1jbw01xig1ge1u0h/subgraphs/bridge-deposits-mainnet/1.0/gn`
+- **Mainnet:** `https://api.goldsky.com/api/public/project_clto8zgmd1jbw01xig1ge1u0h/subgraphs/bridge-deposits-mainnet/prod/gn`
 
 ### Get All ERC20 Deposits by Address
 
@@ -34,12 +34,12 @@ Replace `0x74f65E8feaCC744e0A6Bf654aB75F0A2aee434e2` with the user address:
 
 ```json
 {
-  ethbridgeInitiateds(where:{from_starts_with_nocase:"0x854AD5bFCF0617D77Ef519c628C4037e8F88c2F6"}) {
+  transactionDepositeds(where:{from_starts_with_nocase:"0x854AD5bFCF0617D77Ef519c628C4037e8F88c2F6"}) {
       from
       to
       block_number
       transactionHash_
-      amount
+      opaqueData
   }
 }
 ```

--- a/apps/evm/src/indexer/bridge/README.md
+++ b/apps/evm/src/indexer/bridge/README.md
@@ -30,17 +30,37 @@ Replace `0x854AD5bFCF0617D77Ef519c628C4037e8F88c2F6` with the user address:
 
 ### Get All ETH Deposits by Address
 
-Replace `0x74f65E8feaCC744e0A6Bf654aB75F0A2aee434e2` with the user address:
+Replace `0x97632B3760460A623E068CC70aBF11D5fA99Be5f` with the user address:
 
-```json
-{
-  transactionDepositeds(where:{from_starts_with_nocase:"0x854AD5bFCF0617D77Ef519c628C4037e8F88c2F6"}) {
-      from
-      to
-      block_number
-      transactionHash_
-      opaqueData
+- The first query will give deposit initiated through `L1StandardBridgeProxy` Contract
+- The second query will give deposit initiated through `OptimismPortalProxy` Contract
+- Merge Records from both queries to get all the ETH Deposit done by user
+
+```graphql
+query ThroughL1StandardBridge {
+  ethbridgeInitiateds(
+    where: { from_starts_with_nocase: "0x97632B3760460A623E068CC70aBF11D5fA99Be5f" }
+  ) {
+    from
+    to
+    block_number
+    transactionHash_
+    amount
   }
+}
+```
+
+```graphql
+query ThroughOptimismPortal {
+    transactionDepositeds(
+        where: { from_starts_with_nocase: "0x97632B3760460A623E068CC70aBF11D5fA99Be5f" }
+    ) {
+        from
+        to
+        block_number
+        transactionHash_
+        opaqueData
+    }
 }
 ```
 
@@ -52,7 +72,7 @@ For accessing user withdrawal transactions from Layer 2 (L2) to Layer 1 (L1), us
 
 - **Old Testnet:** `https://api.goldsky.com/api/public/project_clto8zgmd1jbw01xig1ge1u0h/subgraphs/bridge-withdraws-bob-testnet/1.0/gn`
 - **New Testnet:** `https://api.goldsky.com/api/public/project_clto8zgmd1jbw01xig1ge1u0h/subgraphs/testnet-bridge-withdraws-bob-sepolia/test/gn`
-- **Mainnet:** `https://api.goldsky.com/api/public/project_clto8zgmd1jbw01xig1ge1u0h/subgraphs/bridge-withdraws-bob/1.0/gn`
+- **Mainnet:** `https://api.goldsky.com/api/public/project_clto8zgmd1jbw01xig1ge1u0h/subgraphs/bridge-withdraws-bob/prod/gn`
 
 ### Get All ERC20 Withdrawals by Address
 
@@ -74,18 +94,37 @@ Replace `0x02c6107638Dd465D504117043A0F68693D9c64A7` with the user address:
 
 ### Get All ETH Withdrawals by Address
 
-Replace `0xFAEe001465dE6D7E8414aCDD9eF4aC5A35B2B808` with the user address:
+Replace `0x97632B3760460A623E068CC70aBF11D5fA99Be5f` with the user address:
 
-```json
-{
-	ethbridgeInitiateds( where:{from_starts_with_nocase:"0xFAEe001465dE6D7E8414aCDD9eF4aC5A35B2B808"}) {
-    from
-    to
-    block_number
-    transactionHash_
-    amount
-  }
+- The first query will give withdraws initiated through `L2StandardBridge` Contract
+- The second query will give withdraws initiated through `L2ToL1MessagePasser` Contract
+- Merge Records from both queries to get all the ETH Withdraws done by user
+
+```graphql
+query ThroughL2StandardBridgeOnBob {
+    ethbridgeInitiateds(
+        where: { from_starts_with_nocase: "0x97632B3760460A623E068CC70aBF11D5fA99Be5f" }
+    ) {
+        from
+        to
+        block_number
+        transactionHash_
+        amount
+    }
 }
 ```
 
+```graphql
+query ThroughL2MessagePasserOnBob {
+  messagePasseds(
+    where: { sender_starts_with_nocase: "0x97632B3760460A623E068CC70aBF11D5fA99Be5f" }
+  ) {
+    from: sender
+    to: target
+    block_number
+    transactionHash_
+    amount:value
+  }
+}
+```
 ---

--- a/apps/evm/src/indexer/bridge/mainnet_bridge_deposits.json
+++ b/apps/evm/src/indexer/bridge/mainnet_bridge_deposits.json
@@ -10,6 +10,9 @@
     },
     "l1-wsteth-bridge": {
       "path": "./L1BridgeABI.json"
+    },
+    "optimism-portal": {
+      "path": "./OptimismPortal.json"
     }
   },
   "chains": ["mainnet"],
@@ -30,6 +33,12 @@
       "abi": "l1-wsteth-bridge",
       "address": "0x091dF5E1284E49fA682407096aD34cfD42B95B72",
       "startBlock": 19710718,
+      "chain": "mainnet"
+    },
+    {
+      "abi": "optimism-portal",
+      "address": "0x8AdeE124447435fE03e3CD24dF3f4cAE32E65a3E",
+      "startBlock": 19634328,
       "chain": "mainnet"
     }
   ]

--- a/apps/evm/src/indexer/bridge/mainnet_bridge_withdraws.json
+++ b/apps/evm/src/indexer/bridge/mainnet_bridge_withdraws.json
@@ -10,6 +10,9 @@
     },
     "l2-wsteth-bridge": {
       "path": "./L2BridgeABI.json"
+    },
+    "l2-to-l1-message-passer": {
+      "path": "./L2ToL1MessagePasserABI.json"
     }
   },
   "chains": ["bob"],
@@ -30,6 +33,12 @@
       "abi": "l2-wsteth-bridge",
       "address": "0xd1559523374D93972E0F7fE1AA98642754f5c4d1",
       "startBlock": 462151,
+      "chain": "bob"
+    },
+    {
+      "abi": "l2-to-l1-message-passer",
+      "address": "0x4200000000000000000000000000000000000016",
+      "startBlock": 542391,
       "chain": "bob"
     }
   ]

--- a/apps/evm/src/indexer/bridge/new_testnet_bridge_deposits.json
+++ b/apps/evm/src/indexer/bridge/new_testnet_bridge_deposits.json
@@ -4,6 +4,9 @@
   "abis": {
     "bridge": {
       "path": "./L1BridgeABI.json"
+    },
+    "optimism-portal": {
+      "path": "./OptimismPortal.json"
     }
   },
   "chains": ["sepolia"],
@@ -18,6 +21,12 @@
       "abi": "bridge",
       "address": "0xA932eD4b73972c37DC4a691E8eC6f2C8a13951BE",
       "startBlock": 6441278,
+      "chain": "sepolia"
+    },
+    {
+      "abi": "optimism-portal",
+      "address": "0xBAAf3BAfdbd660380938b27d21c31bB7D072a799",
+      "startBlock": 6404317,
       "chain": "sepolia"
     }
   ]

--- a/apps/evm/src/indexer/bridge/new_testnet_bridge_withdraws.json
+++ b/apps/evm/src/indexer/bridge/new_testnet_bridge_withdraws.json
@@ -4,6 +4,9 @@
   "abis": {
     "bridge": {
       "path": "./L2BridgeABI.json"
+    },
+    "l2-to-l1-message-passer": {
+      "path": "./L2ToL1MessagePasserABI.json"
     }
   },
   "chains": ["bob-sepolia"],
@@ -18,6 +21,12 @@
       "abi": "bridge",
       "address": "0x5C2A45A35ba99d8Ee58c4bB96e2Ce30dA86C530b",
       "startBlock": 253101,
+      "chain": "bob-sepolia"
+    },
+    {
+      "abi": "l2-to-l1-message-passer",
+      "address": "0x4200000000000000000000000000000000000016",
+      "startBlock": 2526171,
       "chain": "bob-sepolia"
     }
   ]


### PR DESCRIPTION
With the deprecation of the `op-sdk`, ETH deposits and withdrawals have been updated, requiring adjustments in how they are handled.  

#### ETH Deposits
- **Old Method (via `op-sdk`)**: 
	- Old ways using op sdk we use to call `L1StandardBridgeProxy.bridgeETHTo`. Example [tx](https://etherscan.io/tx/0xd0d5ffd2078f19eb44e11085a1f5da8031d24c66130ff02cd84d3738a0253284)
- **New Method (via `viem`)**: 
	- New way using viem directly calls `OptimismPortalProxy.depositTransaction`. Example [tx](https://etherscan.io/tx/0x70916d057428345425978808f01b6054d4b74034338d31ed441a6467a37e0144)

So to get old and new eth deposit on ui we need to query different events specified in readme. 

#### ETH Withdraw
- **Old Method (via `op-sdk`)**: 
	- Old ways using op sdk we use to call `L2CrossDomainMessenger.relayMessage`. Example [tx](https://explorer.gobob.xyz/tx/0x4ed278d7279e5a7979009befa53e48e1d57dfd62baa6a0d5fdbffc6e5f0714ff)
- **New Method (via `viem`)**: 
	- New way using viem directly calls `L2ToL1MessagePasser.initiateWithdrawal`. Example [tx](https://explorer.gobob.xyz/tx/0x4cf548b5b233f05de97bb009b08cbdc58fe394874222af7859863775df23423f)

So to get old and new eth withdrwaws on ui we need to query different events specified in readme. 

`Note:` Update GQL endpoints link on UI
