### PR TITLE
fix: scan missing wseth withdraw and deposit events

### DIFF
--- a/apps/evm/src/indexer/bridge/README.md
+++ b/apps/evm/src/indexer/bridge/README.md
@@ -12,19 +12,23 @@ To access user deposit transactions from Layer 1 (L1) to Layer 2 (L2), utilize t
 
 ### Get All ERC20 Deposits by Address
 
-Replace `0x854AD5bFCF0617D77Ef519c628C4037e8F88c2F6` with the user address:
+Replace `0x97632B3760460A623E068CC70aBF11D5fA99Be5f` with the user address:
 
-```json
-{
-	erc20BridgeInitiateds( where:{from_starts_with_nocase:"0x854AD5bFCF0617D77Ef519c628C4037e8F88c2F6"}) {
-        localToken
-        remoteToken
+```graphql
+query get_all_erc20_deposits {
+    erc20DepositInitiateds(
+        where: {
+            from_starts_with_nocase: "0x97632B3760460A623E068CC70aBF11D5fA99Be5f"
+        }
+    ) {
+        l1Token
+        l2Token
         from
         to
         block_number
         transactionHash_
         amount
-  }
+    }
 }
 ```
 
@@ -72,19 +76,23 @@ For accessing user withdrawal transactions from Layer 2 (L2) to Layer 1 (L1), us
 
 ### Get All ERC20 Withdrawals by Address
 
-Replace `0x02c6107638Dd465D504117043A0F68693D9c64A7` with the user address:
+Replace `0x97632B3760460A623E068CC70aBF11D5fA99Be5f` with the user address:
 
-```json
-{
-	erc20BridgeInitiateds( where:{from_starts_with_nocase:"0x02c6107638Dd465D504117043A0F68693D9c64A7"}) {
-    localToken
-    remoteToken
-    from
-    to
-    block_number
-    transactionHash_
-    amount
-  }
+```graphql
+query get_all_erc20_withdraws {
+    withdrawalInitiateds(
+        where: {
+            from_starts_with_nocase: "0x97632B3760460A623E068CC70aBF11D5fA99Be5f"
+        }
+    ) {
+        l1Token
+        l2Token
+        from
+        to
+        block_number
+        transactionHash_
+        amount
+    }
 }
 ```
 

--- a/apps/evm/src/indexer/bridge/README.md
+++ b/apps/evm/src/indexer/bridge/README.md
@@ -15,7 +15,7 @@ To access user deposit transactions from Layer 1 (L1) to Layer 2 (L2), utilize t
 Replace `0x97632B3760460A623E068CC70aBF11D5fA99Be5f` with the user address:
 
 ```graphql
-query get_all_erc20_deposits {
+query getERC20Deposits_StandardAndCustomBridges_WSETH_USDC {
     erc20DepositInitiateds(
         where: {
             from_starts_with_nocase: "0x97632B3760460A623E068CC70aBF11D5fA99Be5f"
@@ -79,7 +79,7 @@ For accessing user withdrawal transactions from Layer 2 (L2) to Layer 1 (L1), us
 Replace `0x97632B3760460A623E068CC70aBF11D5fA99Be5f` with the user address:
 
 ```graphql
-query get_all_erc20_withdraws {
+query getERC20Withdrawals_StandardAndCustomBridges_WSETH_USDC {
     withdrawalInitiateds(
         where: {
             from_starts_with_nocase: "0x97632B3760460A623E068CC70aBF11D5fA99Be5f"


### PR DESCRIPTION
##📝 Description 

- The `wseth` deposit doesn't emit `erc20BridgeInitiateds` event, therefore, scan for `erc20DepositInitiateds` event. As we have a custom bridge for it and don't use L1StandardBridge
	- Example: [wseth deposit](https://etherscan.io/tx/0xa6b3ea87bf7ca45a62023d43a2904c2e1fc6d9657f4a63a3b552815fe06fe6c1#eventlog)
	- Example: [other erc20 deposit](https://etherscan.io/tx/0x8efb94f382fbd7c290da30d10fb90245cd3937efc23f9cd8d9988d366c216ff6#eventlog)

- The `wseth` withdraw doesn't emit `erc20BridgeInitiateds` event, therefore, scan for `withdrawalInitiateds` event. As we have a custom bridge for it and don't use L1StandardBridge
	- Example: [wseth withdraw](https://explorer.gobob.xyz/tx/0x75227e47471b93e6335a4d1d90756441f944dfa5548b23d8e2448536c89b7612?tab=logs)
	- Example: [other erc20 withdraw](https://explorer.gobob.xyz/tx/0x56618b58688b51dfece8ea0cdb57c85f3ad1dfa4235ca96d99cb5d79a595e75f?tab=logs)
