### PR TITLE
Div usd amount for ionic by 5

### DIFF
--- a/apps/evm/src/app/[lang]/(bridge)/stake/hooks/useStrategiesContractData.ts
+++ b/apps/evm/src/app/[lang]/(bridge)/stake/hooks/useStrategiesContractData.ts
@@ -253,7 +253,7 @@ const useStrategiesContractData = (
               },
               {
                 address: strategy.contract.outputToken.address as Address,
-                abi: erc20Abi,
+                abi: erc20WithUnderlying,
                 functionName: 'decimals'
               },
               {
@@ -545,7 +545,7 @@ const useStrategiesContractData = (
                 balanceOf > 0n
                   ? {
                       amount: depositAmount,
-                      usd: new Big(depositAmount.toExact()).mul(underlyingPrice).toNumber()
+                      usd: new Big(depositAmount.toExact()).div(5).mul(underlyingPrice).toNumber()
                     }
                   : undefined
             };


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> Add a brief description

Looks like ionic is minting 5x more than tBTC/wBTC lent to their contract. In order to calculate staked usd amount we need to apply the following logic: `balanceOf_ion(t|w)BTC * price_of_underlying / 5`

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path -->

## 📝 Additional Information